### PR TITLE
Kernel: Adds proposed way to transparently redirect platform headers

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -13,6 +13,9 @@
 #ifdef __x86_64__
 #    define AK_ARCH_X86_64 1
 #endif
+#ifdef __aarch64__
+#    define AK_ARCH_AARCH64 1
+#endif
 
 #if defined(__APPLE__) && defined(__MACH__)
 #    define AK_OS_MACOS

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -12,8 +12,8 @@
 #include "RefPtr.h"
 #include "StdLibExtras.h"
 #ifdef KERNEL
-#    include <Kernel/Arch/x86/Processor.h>
-#    include <Kernel/Arch/x86/ScopedCritical.h>
+#    include <Kernel/Arch/Processor.h>
+#    include <Kernel/Arch/ScopedCritical.h>
 #endif
 
 namespace AK {

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -1,0 +1,7 @@
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/Processor.h>
+#elif ARCH(AARCH64)
+#   error "Need to implement this file"
+#else
+#   error "Unknown architecture"
+#endif

--- a/Kernel/Arch/ScopedCritical.h
+++ b/Kernel/Arch/ScopedCritical.h
@@ -1,0 +1,7 @@
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/ScopedCritical.h>
+#elif ARCH(AARCH64)
+#   error "Need to implement this file"
+#else
+#   error "Unknown architecture"
+#endif

--- a/Kernel/AtomicEdgeAction.h
+++ b/Kernel/AtomicEdgeAction.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Atomic.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 
 namespace Kernel {
 

--- a/Kernel/Library/ThreadSafeNonnullRefPtr.h
+++ b/Kernel/Library/ThreadSafeNonnullRefPtr.h
@@ -12,8 +12,8 @@
 #include <AK/Traits.h>
 #include <AK/Types.h>
 #ifdef KERNEL
-#    include <Kernel/Arch/x86/Processor.h>
-#    include <Kernel/Arch/x86/ScopedCritical.h>
+#    include <Kernel/Arch/Processor.h>
+#    include <Kernel/Arch/ScopedCritical.h>
 #endif
 
 #define THREADSAFENONNULLREFPTR_SCRUB_BYTE 0xa1

--- a/Kernel/Library/ThreadSafeRefPtr.h
+++ b/Kernel/Library/ThreadSafeRefPtr.h
@@ -15,8 +15,8 @@
 #include <AK/Types.h>
 #ifdef KERNEL
 #    include <Kernel/API/KResult.h>
-#    include <Kernel/Arch/x86/Processor.h>
-#    include <Kernel/Arch/x86/ScopedCritical.h>
+#    include <Kernel/Arch/Processor.h>
+#    include <Kernel/Arch/ScopedCritical.h>
 #endif
 
 #define THREADSAFEREFPTR_SCRUB_BYTE 0xa0

--- a/Kernel/Locking/Spinlock.h
+++ b/Kernel/Locking/Spinlock.h
@@ -8,7 +8,7 @@
 
 #include <AK/Atomic.h>
 #include <AK/Types.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Locking/LockRank.h>
 
 namespace Kernel {

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Format.h>
 #include <Kernel/Arch/x86/IO.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/CommandLine.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <AK/Singleton.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>

--- a/Kernel/UBSanitizer.cpp
+++ b/Kernel/UBSanitizer.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Format.h>
 #include <AK/UBSanitizer.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/KSyms.h>
 
 using namespace Kernel;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <AK/Types.h>
-#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/BootInfo.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Initializer.h>


### PR DESCRIPTION
After a discussion here: https://discord.com/channels/830522505605283862/830525093905170492/896863430017953833 with @nico - I have started on getting the AK_SOURCES to compile for aarch64.

First step I think is to "hide" the platform specific headers from the library code. This PR proposes a solution to that.

Eventually, machine independent but hardware related datastructures and code can live in the shared headers. Additional platform specific code and datastructures can be included based on the target platform... however, pretty much all non-platform specific code should only rely on the machine independent data structures and code.